### PR TITLE
changed all dimvec array sizes to 12 to avoid possible memory overwrites

### DIFF
--- a/iric_ftoc.c
+++ b/iric_ftoc.c
@@ -681,23 +681,23 @@ void IRICLIBDLL FMNAME(cg_iric_read_grid_functional_real_cell_mul_f, CG_IRIC_REA
 }
 
 void IRICLIBDLL FMNAME(cg_iric_writegridcoord1d_mul_f, CG_IRIC_WRITEGRIDCOORD1D_MUL_F) (int *fid, int *isize, double *x, int *ier) {
-	int c_isize;
+	cgsize_t c_isize;
 	c_isize = (cgsize_t)(*isize);
 	*ier = cg_iRIC_WriteGridCoord1d_Mul(*fid, c_isize, x);
 }
 
 void IRICLIBDLL FMNAME(cg_iric_writegridcoord2d_mul_f, CG_IRIC_WRITEGRIDCOORD2D_MUL_F) (int *fid, int *isize, int *jsize, double *x, double *y, int *ier) {
-	int c_isize;
-	int c_jsize;
+	cgsize_t c_isize;
+	cgsize_t c_jsize;
 	c_isize = (cgsize_t)(*isize);
 	c_jsize = (cgsize_t)(*jsize);
 	*ier = cg_iRIC_WriteGridCoord2d_Mul(*fid, c_isize, c_jsize, x, y);
 }
 
 void IRICLIBDLL FMNAME(cg_iric_writegridcoord3d_mul_f, CG_IRIC_WRITEGRIDCOORD3D_MUL_F) (int *fid, int *isize, int *jsize, int *ksize, double *x, double *y, double *z, int *ier) {
-	int c_isize;
-	int c_jsize;
-	int c_ksize;
+	cgsize_t c_isize;
+	cgsize_t c_jsize;
+	cgsize_t c_ksize;
 	c_isize = (cgsize_t)(*isize);
 	c_jsize = (cgsize_t)(*jsize);
 	c_ksize = (cgsize_t)(*ksize);
@@ -1235,13 +1235,13 @@ void IRICLIBDLL FMNAME(cg_iric_write_bc_functionalwithname_string_mul_f, CG_IRIC
 }
 
 void IRICLIBDLL FMNAME(cg_iric_write_sol_particle_pos2d_mul_f, CG_IRIC_WRITE_SOL_PARTICLE_POS2D_MUL_F) (int *fid, int *count, double *x, double *y, int *ier) {
-	int c_count;
+	cgsize_t c_count;
 	c_count = (cgsize_t)(*count);
 	*ier = cg_iRIC_Write_Sol_Particle_Pos2d_Mul(*fid, c_count, x, y);
 }
 
 void IRICLIBDLL FMNAME(cg_iric_write_sol_particle_pos3d_mul_f, CG_IRIC_WRITE_SOL_PARTICLE_POS3D_MUL_F) (int *fid, int *count, double *x, double *y, double *z, int *ier) {
-	int c_count;
+	cgsize_t c_count;
 	c_count = (cgsize_t)(*count);
 	*ier = cg_iRIC_Write_Sol_Particle_Pos3d_Mul(*fid, c_count, x, y, z);
 }
@@ -2015,23 +2015,23 @@ void IRICLIBDLL FMNAME(cg_iric_read_grid_functional_real_cell_f, CG_IRIC_READ_GR
 }
 
 void IRICLIBDLL FMNAME(cg_iric_writegridcoord1d_f, CG_IRIC_WRITEGRIDCOORD1D_F) (int *isize, double *x, int *ier) {
-	int c_isize;
+	cgsize_t c_isize;
 	c_isize = (cgsize_t)(*isize);
 	*ier = cg_iRIC_WriteGridCoord1d(c_isize, x);
 }
 
 void IRICLIBDLL FMNAME(cg_iric_writegridcoord2d_f, CG_IRIC_WRITEGRIDCOORD2D_F) (int *isize, int *jsize, double *x, double *y, int *ier) {
-	int c_isize;
-	int c_jsize;
+	cgsize_t c_isize;
+	cgsize_t c_jsize;
 	c_isize = (cgsize_t)(*isize);
 	c_jsize = (cgsize_t)(*jsize);
 	*ier = cg_iRIC_WriteGridCoord2d(c_isize, c_jsize, x, y);
 }
 
 void IRICLIBDLL FMNAME(cg_iric_writegridcoord3d_f, CG_IRIC_WRITEGRIDCOORD3D_F) (int *isize, int *jsize, int *ksize, double *x, double *y, double *z, int *ier) {
-	int c_isize;
-	int c_jsize;
-	int c_ksize;
+	cgsize_t c_isize;
+	cgsize_t c_jsize;
+	cgsize_t c_ksize;
 	c_isize = (cgsize_t)(*isize);
 	c_jsize = (cgsize_t)(*jsize);
 	c_ksize = (cgsize_t)(*ksize);
@@ -2569,13 +2569,13 @@ void IRICLIBDLL FMNAME(cg_iric_write_bc_functionalwithname_string_f, CG_IRIC_WRI
 }
 
 void IRICLIBDLL FMNAME(cg_iric_write_sol_particle_pos2d_f, CG_IRIC_WRITE_SOL_PARTICLE_POS2D_F) (int *count, double *x, double *y, int *ier) {
-	int c_count;
+	cgsize_t c_count;
 	c_count = (cgsize_t)(*count);
 	*ier = cg_iRIC_Write_Sol_Particle_Pos2d(c_count, x, y);
 }
 
 void IRICLIBDLL FMNAME(cg_iric_write_sol_particle_pos3d_f, CG_IRIC_WRITE_SOL_PARTICLE_POS3D_F) (int *count, double *x, double *y, double *z, int *ier) {
-	int c_count;
+	cgsize_t c_count;
 	c_count = (cgsize_t)(*count);
 	*ier = cg_iRIC_Write_Sol_Particle_Pos3d(c_count, x, y, z);
 }

--- a/iriclib.cpp
+++ b/iriclib.cpp
@@ -925,6 +925,9 @@ int cg_iRIC_Read_BC_IndicesSize_Mul(int fid, const char* type, int num, cgsize_t
 
 int cg_iRIC_Read_BC_Indices_Mul(int fid, const char* type, int num, cgsize_t* indices)
 {
+#if (CG_SIZEOF_SIZE != 32)
+#error CG_IRIC_READ_BC_INDICES_F and CG_IRIC_READ_BC_INDICES_MUL_F need to be updated!
+#endif
 	GET_F(fid);
 	return f->BC_Read_Indices(type, num, indices);
 }

--- a/iriclib_cgnsfile_base.cpp
+++ b/iriclib_cgnsfile_base.cpp
@@ -235,7 +235,7 @@ int CgnsFile::Impl::loadResultData()
 		char name[NAME_MAXLENGTH];
 		DataType_t datatype;
 		int dim;
-		cgsize_t dimvec[2];
+		cgsize_t dimvec[Impl::MAX_DIMS];
 
 		ier = cg_array_info(i, name, &datatype, &dim, dimvec);
 		RETURN_IF_ERR;
@@ -583,9 +583,9 @@ int CgnsFile::Impl::readArray(const char* name, DataType_t dataType, cgsize_t le
 	int index;
 	DataType_t dt;
 	int dim;
-	cgsize_t dimVec[3];
+	cgsize_t dimVec[Impl::MAX_DIMS];
 
-	int ier = findArray(name, &index, &dt, &dim, &(dimVec[0]));
+	int ier = findArray(name, &index, &dt, &dim, dimVec);
 	RETURN_IF_ERR;
 
 	// check datatype;
@@ -603,9 +603,9 @@ int CgnsFile::Impl::readArrayAs(const char* name, DataType_t dataType, size_t le
 	int index;
 	DataType_t dt;
 	int dim;
-	cgsize_t dimVec[3];
+	cgsize_t dimVec[Impl::MAX_DIMS];
 
-	int ier = findArray(name, &index, &dt, &dim, &(dimVec[0]));
+	int ier = findArray(name, &index, &dt, &dim, dimVec);
 	RETURN_IF_ERR;
 
 	// check datalength if needed
@@ -621,9 +621,9 @@ int CgnsFile::Impl::readStringLen(const char* name, int* length)
 	int index;
 	DataType_t datatype;
 	int dim;
-	cgsize_t dimVec[3];
+	cgsize_t dimVec[Impl::MAX_DIMS];
 
-	int ier = findArray(name, &index, &datatype, &dim, &(dimVec[0]));
+	int ier = findArray(name, &index, &datatype, &dim, dimVec);
 	RETURN_IF_ERR;
 
 	if (datatype != Character){return -1;}
@@ -638,9 +638,9 @@ int CgnsFile::Impl::readString(const char* name, size_t bufferLen, char* buffer)
 	int index;
 	DataType_t datatype;
 	int dim;
-	cgsize_t dimVec[3];
+	cgsize_t dimVec[Impl::MAX_DIMS];
 
-	int ier = findArray(name, &index, &datatype, &dim, &(dimVec[0]));
+	int ier = findArray(name, &index, &datatype, &dim, dimVec);
 
 	// check datatype
 	if (datatype != Character){return -1;}

--- a/iriclib_cgnsfile_bc.cpp
+++ b/iriclib_cgnsfile_bc.cpp
@@ -106,9 +106,9 @@ int CgnsFile::BC_Read_FunctionalSize(const char *typeName, int num, const char *
 		char arrayname[Impl::NAME_MAXLENGTH];
 		DataType_t datatype;
 		int dim;
-		cgsize_t dimvec;
-		ier = cg_array_info(i, arrayname, &datatype, &dim, &dimvec);
-		*size = dimvec;
+		cgsize_t dimvec[Impl::MAX_DIMS];
+		ier = cg_array_info(i, arrayname, &datatype, &dim, dimvec);
+		*size = dimvec[0];
 		return 0;
 	}
 	return 1;

--- a/iriclib_cgnsfile_cc.cpp
+++ b/iriclib_cgnsfile_cc.cpp
@@ -52,9 +52,9 @@ int CgnsFile::CC_Read_FunctionalSize(const char *name, cgsize_t* size)
 		char arrayname[Impl::NAME_MAXLENGTH];
 		DataType_t datatype;
 		int dim;
-		cgsize_t dimvec;
-		ier = cg_array_info(i, arrayname, &datatype, &dim, &dimvec);
-		*size = dimvec;
+		cgsize_t dimvec[Impl::MAX_DIMS];
+		ier = cg_array_info(i, arrayname, &datatype, &dim, dimvec);
+		*size = dimvec[0];
 		return 0;
 	}
 	return 1;

--- a/iriclib_cgnsfile_complex_cc.cpp
+++ b/iriclib_cgnsfile_complex_cc.cpp
@@ -59,9 +59,9 @@ int CgnsFile::Complex_CC_Read_FunctionalSize(const char *groupname, int num, con
 		char arrayname[Impl::NAME_MAXLENGTH];
 		DataType_t datatype;
 		int dim;
-		cgsize_t dimvec;
-		ier = cg_array_info(i, arrayname, &datatype, &dim, &dimvec);
-		*size = dimvec;
+		cgsize_t dimvec[Impl::MAX_DIMS];
+		ier = cg_array_info(i, arrayname, &datatype, &dim, dimvec);
+		*size = dimvec[0];
 		return 0;
 	}
 	return 1;

--- a/iriclib_cgnsfile_grid.cpp
+++ b/iriclib_cgnsfile_grid.cpp
@@ -127,8 +127,8 @@ int CgnsFile::Grid_Read_FunctionalDimensionSize(const char* name, const char* di
 	int index;
 	DataType_t datatype;
 	int dim;
-	cgsize_t dimvec[3];
-	ier = Impl::findArray(dimArrayName, &index, &datatype, &dim, &(dimvec[0]));
+	cgsize_t dimvec[Impl::MAX_DIMS];
+	ier = Impl::findArray(dimArrayName, &index, &datatype, &dim, dimvec);
 	RETURN_IF_ERR;
 
 	*count = dimvec[0];

--- a/private/iriclib_cgnsfile_impl.h
+++ b/private/iriclib_cgnsfile_impl.h
@@ -13,6 +13,7 @@ class CgnsFile::Impl
 {
 public:
 	static const int NAME_MAXLENGTH = 200;
+	static const int MAX_DIMS = 12;
 
 	static const int VERTEX_SOLUTION_ID   = 1;
 	static const int CELL_SOLUTION_ID     = 2;

--- a/private/iriclib_cgnsfile_solutionwriterstandard.cpp
+++ b/private/iriclib_cgnsfile_solutionwriterstandard.cpp
@@ -283,11 +283,11 @@ int CgnsFile::SolutionWriterStandard::stdSolParticleWriteReal(const char* name, 
 	char arrayname[32];
 	DataType_t datatype;
 	int dim;
-	cgsize_t dimVec;
-	ier = cg_array_info(1, arrayname, &datatype, &dim, &dimVec);
+	cgsize_t dimVec[Impl::MAX_DIMS];
+	ier = cg_array_info(1, arrayname, &datatype, &dim, dimVec);
 	RETURN_IF_ERR;
 
-	return Impl::writeArray(name, RealDouble, static_cast<size_t> (dimVec), value);
+	return Impl::writeArray(name, RealDouble, static_cast<size_t> (dimVec[0]), value);
 }
 
 int CgnsFile::SolutionWriterStandard::stdSolParticleWriteInteger(const char* name, int* value, int fid, int bid, int zid, int sid)
@@ -300,9 +300,9 @@ int CgnsFile::SolutionWriterStandard::stdSolParticleWriteInteger(const char* nam
 	char arrayname[32];
 	DataType_t datatype;
 	int dim;
-	cgsize_t dimVec;
-	ier = cg_array_info(1, arrayname, &datatype, &dim, &dimVec);
+	cgsize_t dimVec[Impl::MAX_DIMS];
+	ier = cg_array_info(1, arrayname, &datatype, &dim, dimVec);
 	RETURN_IF_ERR;
 
-	return Impl::writeArray(name, Integer, static_cast<size_t> (dimVec), value);
+	return Impl::writeArray(name, Integer, static_cast<size_t> (dimVec[0]), value);
 }

--- a/unittests_cgnsfile/case_grid.cpp
+++ b/unittests_cgnsfile/case_grid.cpp
@@ -187,7 +187,7 @@ void case_GridWrite()
 	int dim;
 	char name[32];
 	DataType_t datatype;
-	cgsize_t dimVec[3];
+	cgsize_t dimVec[12];
 	ier = cg_array_info(1, name, &datatype, &dim, dimVec);
 	VERIFY_LOG("cg_array_info() ier == 0", ier == 0);
 	VERIFY_LOG("cg_array_info() name == CoordinateX", std::string("CoordinateX") == name);


### PR DESCRIPTION
Hi Keisuke,

I started working on this before I saw your pull request.  I was getting an error (buffer overrun) when I was testing i-RIC/prepost-gui#680 using the issue-580.ipro file.  I modified all the calls to cg_array_info so that the dimvec variable is always at the max of 12.
(see https://github.com/scharlton2/CGNS/blob/v3.2.1-patch1/src/cgns_header.h#L205
and
https://github.com/scharlton2/CGNS/blob/v3.2.1-patch1/src/cgnslib.c#L8843).

Thanks,
Scott

